### PR TITLE
fix(frontend): vite health check timeout error

### DIFF
--- a/packages/myfy-frontend/myfy/frontend/module.py
+++ b/packages/myfy-frontend/myfy/frontend/module.py
@@ -257,8 +257,7 @@ class FrontendModule:
             try:
                 # Use asyncio to connect (non-blocking)
                 reader, writer = await asyncio.wait_for(
-                    asyncio.open_connection(host, port),
-                    timeout=1.0
+                    asyncio.open_connection(host, port), timeout=1.0
                 )
 
                 # Send a simple HTTP GET request to check if Vite is responding


### PR DESCRIPTION
Fixes the Vite dev server health check that was consistently failing even when Vite was working correctly.

Changes:
- Replace string manipulation with urllib.parse for proper URL parsing
- Use async I/O (asyncio.open_connection) instead of blocking socket calls
- Verify HTTP response instead of just checking if port is open
- Improve error handling with specific exception types
- Add better debug logging for troubleshooting

This resolves the "Vite server not responding after 10.0s" warning that appeared even when the server was functioning normally.